### PR TITLE
Fix podcast sorting logic

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,0 +1,8 @@
+export default [
+    { title: "Scrimba Podcast", duration: 50 },
+    { title: "Crime Fan", duration: 150 },
+    { title: "Mythical Creatures", duration: 99 },
+    { title: "Something about Witches", duration: 35 },
+    { title: "Crime Crime Crime", duration: 70 },
+    { title: "Coding Corner", duration: 55 }
+];

--- a/index.js
+++ b/index.js
@@ -1,0 +1,39 @@
+import podcasts from "./data.js";
+
+/* Welcome Aboard Scrimba Airlines
+
+Our Scrimba Airlines in-flight entertainment package
+includes a variety of podcasts. We need to add a feature that suggests
+podcasts to our patrons based on whether a flight is short or long.
+
+Your sort function should take two arguments: the podcast data and
+flight length. If the flight is 60 minutes or less, sort the podcast list
+from shortest to longest. If it's anything else, sort from longest
+to shortest.
+
+Your function shouldn't return anything. Instead log a numbered list
+of the title and duration of
+each podcast to the console, like this:
+
+1. Crime Fan, 150 minutes
+2. Mythical Creatures, 99 minutes
+3. Crime Crime Crime, 70 minutes
+4. Coding Corner, 55 minutes
+5. Scrimba Podcast, 50 minutes
+6. Something about Witches, 35 minutes
+
+*/
+
+function sortByDuration(data, flightLength){
+    if (flightLength <= 60) {
+        data.sort((a, b) => a.duration - b.duration);
+    } else {
+        data.sort((a, b) => b.duration - a.duration);
+    }
+
+    data.forEach((podcast, index) => {
+        console.log(`${index + 1}. ${podcast.title}, ${podcast.duration} minutes`);
+    });
+}
+
+sortByDuration(podcasts, 60);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Implemented the `sortByDuration` function to correctly sort podcasts based on flight length. Added `package.json` and `data.js` to create a working environment. The function now logs the sorted list to the console as required, instead of returning an array.

---
*PR created automatically by Jules for task [9325228207814598614](https://jules.google.com/task/9325228207814598614) started by @CodebyPallavi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Podcast data module with catalog information including titles and durations
  * Dynamic sorting algorithm organizing podcasts by duration based on flight length parameters
  * Formatted console output displaying sorted podcasts with titles and durations

* **Chores**
  * Enabled ES modules in project configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->